### PR TITLE
refactor: melhorar o tratamento de resposta nos controladores - Fixes #8

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -4,15 +4,13 @@ import {
 	HttpCode,
 	HttpStatus,
 	Post,
-	Res,
 	UsePipes,
 } from '@nestjs/common';
-import type { Response } from 'express';
 import { ZodValidationPipe } from '../common/pipes';
 import { LoginSchema } from './auth.schema';
 // biome-ignore lint/style/useImportType: falso positivo, o nest precisa usar isso na injeção de dependência
 import { AuthService } from './auth.service';
-import type { LoginDto } from './auth.types';
+import type { LoginDto, LoginResponse } from './auth.types';
 
 @Controller('auth')
 export class AuthController {
@@ -21,8 +19,8 @@ export class AuthController {
 	@HttpCode(HttpStatus.OK)
 	@Post('login')
 	@UsePipes(new ZodValidationPipe(LoginSchema))
-	async login(@Body() dto: LoginDto, @Res() res: Response): Promise<Response> {
+	async login(@Body() dto: LoginDto): Promise<LoginResponse> {
 		const loginResponse = await this.authService.login(dto);
-		return res.json(loginResponse);
+		return loginResponse;
 	}
 }

--- a/src/auth/tests/auth.controller.spec.ts
+++ b/src/auth/tests/auth.controller.spec.ts
@@ -1,5 +1,4 @@
 import { Test, type TestingModule } from '@nestjs/testing';
-import type { Response } from 'express';
 import { AuthController } from '../auth.controller';
 import { AuthService } from '../auth.service';
 import type { LoginDto, LoginResponse } from '../auth.types';
@@ -7,14 +6,6 @@ import type { LoginDto, LoginResponse } from '../auth.types';
 describe('AuthController', () => {
 	let controller: AuthController;
 	let authService: jest.Mocked<AuthService>;
-
-	const mockResponse = () => {
-		const res: Partial<Response> = {
-			json: jest.fn().mockReturnThis(),
-			status: jest.fn().mockReturnThis(),
-		};
-		return res as Response;
-	};
 
 	beforeEach(async () => {
 		const module: TestingModule = await Test.createTestingModule({
@@ -53,18 +44,14 @@ describe('AuthController', () => {
 		};
 
 		it('should login successfully and return access token', async () => {
-			const res = mockResponse();
-
 			authService.login.mockResolvedValue(mockLoginResponse);
 
-			await controller.login(mockLoginDto, res);
+			await controller.login(mockLoginDto);
 
 			expect(authService.login).toHaveBeenCalledWith(mockLoginDto);
-			expect(res.json).toHaveBeenCalledWith(mockLoginResponse);
 		});
 
 		it('should validate body with LoginSchema', async () => {
-			const res = mockResponse();
 			const validBody: LoginDto = {
 				email: 'jane@example.com',
 				password: 'Password123',
@@ -74,18 +61,17 @@ describe('AuthController', () => {
 				...mockLoginResponse,
 			});
 
-			await controller.login(validBody, res);
+			await controller.login(validBody);
 
 			expect(authService.login).toHaveBeenCalledWith(validBody);
 		});
 
 		it('should propagate error from service', async () => {
-			const res = mockResponse();
 			const error = new Error('Service error');
 
 			authService.login.mockRejectedValue(error);
 
-			await expect(controller.login(mockLoginDto, res)).rejects.toThrow(error);
+			await expect(controller.login(mockLoginDto)).rejects.toThrow(error);
 
 			expect(authService.login).toHaveBeenCalledWith(mockLoginDto);
 		});

--- a/src/health/health.controller.ts
+++ b/src/health/health.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get } from '@nestjs/common';
+import { Controller, Get, HttpCode, HttpStatus } from '@nestjs/common';
 // biome-ignore lint/style/useImportType: falso positivo, o nest precisa das classes para injeção de dependência
 import {
 	HealthCheck,
@@ -18,6 +18,7 @@ export class HealthController {
 		private memory: MemoryHealthIndicator,
 	) {}
 
+	@HttpCode(HttpStatus.OK)
 	@Get('version')
 	getVersion() {
 		return {
@@ -27,6 +28,7 @@ export class HealthController {
 		};
 	}
 
+	@HttpCode(HttpStatus.OK)
 	@Get('http')
 	@HealthCheck()
 	httpHealth() {
@@ -35,12 +37,14 @@ export class HealthController {
 		]);
 	}
 
+	@HttpCode(HttpStatus.OK)
 	@Get('db')
 	@HealthCheck()
 	dbHealth() {
 		return this.health.check([() => this.db.pingCheck('database')]);
 	}
 
+	@HttpCode(HttpStatus.OK)
 	@Get('memory')
 	@HealthCheck()
 	memoryHealth() {

--- a/src/user/tests/user.controller.spec.ts
+++ b/src/user/tests/user.controller.spec.ts
@@ -1,5 +1,4 @@
 import { Test, type TestingModule } from '@nestjs/testing';
-import type { Response } from 'express';
 import { UserController } from '../user.controller';
 import { UserService } from '../user.service';
 import type { CreatedUserResponse, UserCreateDto } from '../user.types';
@@ -7,14 +6,6 @@ import type { CreatedUserResponse, UserCreateDto } from '../user.types';
 describe('UserController', () => {
 	let controller: UserController;
 	let userService: jest.Mocked<UserService>;
-
-	const mockResponse = () => {
-		const res: Partial<Response> = {
-			json: jest.fn().mockReturnThis(),
-			status: jest.fn().mockReturnThis(),
-		};
-		return res as Response;
-	};
 
 	beforeEach(async () => {
 		const module: TestingModule = await Test.createTestingModule({
@@ -56,18 +47,14 @@ describe('UserController', () => {
 		};
 
 		it('should create a user successfully and return the correct response', async () => {
-			const res = mockResponse();
-
 			userService.createUser.mockResolvedValue(mockCreatedUserResponse);
 
-			await controller.createUser(mockUserCreateDto, res);
+			await controller.createUser(mockUserCreateDto);
 
 			expect(userService.createUser).toHaveBeenCalledWith(mockUserCreateDto);
-			expect(res.json).toHaveBeenCalledWith(mockCreatedUserResponse);
 		});
 
 		it('should validate body with UserCreateSchema', async () => {
-			const res = mockResponse();
 			const validBody = {
 				name: 'Jane Doe',
 				email: 'jane@example.com',
@@ -80,13 +67,12 @@ describe('UserController', () => {
 				email: 'jane@example.com',
 			});
 
-			await controller.createUser(validBody, res);
+			await controller.createUser(validBody);
 
 			expect(userService.createUser).toHaveBeenCalledWith(validBody);
 		});
 
 		it('should accept body without name (optional field)', async () => {
-			const res = mockResponse();
 			const validBodyWithoutName = {
 				email: 'john@example.com',
 				password: 'SecurePassword123',
@@ -97,21 +83,19 @@ describe('UserController', () => {
 				name: undefined as unknown as string,
 			});
 
-			await controller.createUser(validBodyWithoutName, res);
+			await controller.createUser(validBodyWithoutName);
 
 			expect(userService.createUser).toHaveBeenCalledWith(validBodyWithoutName);
-			expect(res.json).toHaveBeenCalled();
 		});
 
 		it('should propagate error from service', async () => {
-			const res = mockResponse();
 			const error = new Error('Service error');
 
 			userService.createUser.mockRejectedValue(error);
 
-			await expect(
-				controller.createUser(mockUserCreateDto, res),
-			).rejects.toThrow(error);
+			await expect(controller.createUser(mockUserCreateDto)).rejects.toThrow(
+				error,
+			);
 
 			expect(userService.createUser).toHaveBeenCalledWith(mockUserCreateDto);
 		});

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -1,23 +1,27 @@
-import { Body, Controller, Post, Res, UsePipes } from '@nestjs/common';
-import type { Response } from 'express';
+import {
+	Body,
+	Controller,
+	HttpCode,
+	HttpStatus,
+	Post,
+	UsePipes,
+} from '@nestjs/common';
 import { ZodValidationPipe } from '../common/pipes';
 import { UserCreateSchema } from './user.schema';
 // biome-ignore lint/style/useImportType: falso positivo, o nest precisa usar isso na injeção de dependência
 import { UserService } from './user.service';
-import type { UserCreateDto } from './user.types';
+import type { CreatedUserResponse, UserCreateDto } from './user.types';
 
 @Controller('user')
 export class UserController {
 	constructor(private userService: UserService) {}
 
 	@Post()
+	@HttpCode(HttpStatus.CREATED)
 	@UsePipes(new ZodValidationPipe(UserCreateSchema))
-	async createUser(
-		@Body() body: UserCreateDto,
-		@Res() res: Response,
-	): Promise<Response> {
+	async createUser(@Body() body: UserCreateDto): Promise<CreatedUserResponse> {
 		const createdUser = await this.userService.createUser(body);
 
-		return res.json(createdUser);
+		return createdUser;
 	}
 }


### PR DESCRIPTION
Melhora o tratamento de respostas dos controllers por devolver o retorno sem a response, assim os interceptors podem trabalhar.

Fixes #8 