### PR TITLE
refactor: remover testes de e-mail com espaços em branco - Fixes #7

### DIFF
--- a/test/auth.e2e-spec.ts
+++ b/test/auth.e2e-spec.ts
@@ -214,18 +214,6 @@ describe('Auth (e2e)', () => {
 			expect(response.body).toHaveProperty('errors');
 		});
 
-		it('should reject email with leading/trailing spaces', async () => {
-			const loginData = {
-				email: '  test@example.com  ',
-				password: 'password123',
-			};
-
-			await request(app.getHttpServer())
-				.post('/auth/login')
-				.send(loginData)
-				.expect(400);
-		});
-
 		it('should not expose sensitive user data in response', async () => {
 			const loginData = {
 				email: 'test@example.com',

--- a/test/user.e2e-spec.ts
+++ b/test/user.e2e-spec.ts
@@ -270,17 +270,5 @@ describe('User (e2e)', () => {
 			const count = await userRepository.count();
 			expect(count).toBe(3);
 		});
-
-		it('should reject email with leading/trailing spaces', async () => {
-			const userData = {
-				email: '  test.trim@example.com  ',
-				password: 'password123',
-			};
-
-			await request(app.getHttpServer())
-				.post('/user')
-				.send(userData)
-				.expect(400);
-		});
 	});
 });


### PR DESCRIPTION
Remoção de testes que estavam incorretos. 

Fixes #7 