### PR TITLE
feat: criar middleware de log para registrar requisições HTTP

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,10 +1,15 @@
-import { Module } from '@nestjs/common';
+import {
+	type MiddlewareConsumer,
+	Module,
+	type NestModule,
+} from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { JwtModule } from '@nestjs/jwt';
 import { ScheduleModule } from '@nestjs/schedule';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AuthModule } from './auth/auth.module';
 import { BcryptModule } from './bcrypt/bcrypt.module';
+import { LogMiddleware } from './common/middlewares';
 import { jwtRegisterConfig, typeOrmConfig, validateEnv } from './config';
 import { HealthModule } from './health/health.module';
 import { LinkModule } from './link/link.module';
@@ -38,4 +43,8 @@ import { UserModule } from './user/user.module';
 	controllers: [],
 	providers: [],
 })
-export class AppModule {}
+export class AppModule implements NestModule {
+	configure(consumer: MiddlewareConsumer) {
+		consumer.apply(LogMiddleware).forRoutes('*');
+	}
+}

--- a/src/common/middlewares/index.ts
+++ b/src/common/middlewares/index.ts
@@ -1,0 +1,1 @@
+export * from './log.middleware';

--- a/src/common/middlewares/log.middleware.ts
+++ b/src/common/middlewares/log.middleware.ts
@@ -1,0 +1,31 @@
+import type { NestMiddleware } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
+import type { NextFunction, Request, Response } from 'express';
+
+@Injectable()
+export class LogMiddleware implements NestMiddleware {
+	private readonly logger = new Logger('HTTP');
+
+	use(req: Request, res: Response, next: NextFunction) {
+		const { method, originalUrl, ip } = req;
+		const userAgent = req.get('user-agent') || '';
+		const startTime = Date.now();
+
+		// Log da requisição
+		this.logger.log(`→ ${method} ${originalUrl} - ${ip} - ${userAgent}`);
+
+		// Intercepta o final da resposta
+		res.on('finish', () => {
+			const { statusCode } = res;
+			const responseTime = Date.now() - startTime;
+			const statusEmoji =
+				statusCode >= 400 ? '❌' : statusCode >= 300 ? '↩️' : '✅';
+
+			this.logger.log(
+				`${statusEmoji} ${method} ${originalUrl} ${statusCode} - ${responseTime}ms`,
+			);
+		});
+
+		next();
+	}
+}

--- a/src/common/tests/log.middleware.spec.ts
+++ b/src/common/tests/log.middleware.spec.ts
@@ -1,0 +1,175 @@
+import { Logger } from '@nestjs/common';
+import type { NextFunction, Request, Response } from 'express';
+import { LogMiddleware } from '../middlewares/log.middleware';
+
+describe('LogMiddleware', () => {
+	let middleware: LogMiddleware;
+	let mockRequest: Partial<Request>;
+	let mockResponse: Partial<Response>;
+	let mockNext: NextFunction;
+	let logSpy: jest.SpyInstance;
+
+	beforeEach(() => {
+		middleware = new LogMiddleware();
+
+		mockRequest = {
+			method: 'GET',
+			originalUrl: '/test',
+			ip: '127.0.0.1',
+			get: jest.fn((header: string) => {
+				if (header === 'user-agent') return 'test-agent';
+				return '';
+			}) as unknown as Request['get'],
+		};
+
+		const listeners: { [event: string]: (() => void)[] } = {};
+		mockResponse = {
+			statusCode: 200,
+			on: jest.fn((event: string, callback: () => void) => {
+				listeners[event] = listeners[event] || [];
+				listeners[event].push(callback);
+				return mockResponse as Response;
+			}),
+			emit: jest.fn((event: string) => {
+				if (listeners[event]) {
+					for (const callback of listeners[event]) {
+						callback();
+					}
+				}
+				return true;
+			}),
+		};
+
+		mockNext = jest.fn();
+
+		logSpy = jest.spyOn(Logger.prototype, 'log').mockImplementation();
+	});
+
+	afterEach(() => {
+		jest.clearAllMocks();
+		jest.restoreAllMocks();
+	});
+
+	it('should be defined', () => {
+		expect(middleware).toBeDefined();
+	});
+
+	it('should log incoming request with method, url, ip and user-agent', () => {
+		middleware.use(mockRequest as Request, mockResponse as Response, mockNext);
+
+		expect(logSpy).toHaveBeenCalledWith('→ GET /test - 127.0.0.1 - test-agent');
+	});
+
+	it('should call next function', () => {
+		middleware.use(mockRequest as Request, mockResponse as Response, mockNext);
+
+		expect(mockNext).toHaveBeenCalled();
+	});
+
+	it('should log response with success emoji for 2xx status', () => {
+		jest.useFakeTimers();
+
+		middleware.use(mockRequest as Request, mockResponse as Response, mockNext);
+
+		jest.advanceTimersByTime(50);
+		mockResponse.statusCode = 200;
+		(mockResponse.emit as jest.Mock)('finish');
+
+		expect(logSpy).toHaveBeenCalledWith('✅ GET /test 200 - 50ms');
+
+		jest.useRealTimers();
+	});
+
+	it('should log response with redirect emoji for 3xx status', () => {
+		jest.useFakeTimers();
+
+		middleware.use(mockRequest as Request, mockResponse as Response, mockNext);
+
+		jest.advanceTimersByTime(25);
+		mockResponse.statusCode = 301;
+		(mockResponse.emit as jest.Mock)('finish');
+
+		expect(logSpy).toHaveBeenCalledWith('↩️ GET /test 301 - 25ms');
+
+		jest.useRealTimers();
+	});
+
+	it('should log response with error emoji for 4xx status', () => {
+		jest.useFakeTimers();
+
+		middleware.use(mockRequest as Request, mockResponse as Response, mockNext);
+
+		jest.advanceTimersByTime(30);
+		mockResponse.statusCode = 404;
+		(mockResponse.emit as jest.Mock)('finish');
+
+		expect(logSpy).toHaveBeenCalledWith('❌ GET /test 404 - 30ms');
+
+		jest.useRealTimers();
+	});
+
+	it('should log response with error emoji for 5xx status', () => {
+		jest.useFakeTimers();
+
+		middleware.use(mockRequest as Request, mockResponse as Response, mockNext);
+
+		jest.advanceTimersByTime(100);
+		mockResponse.statusCode = 500;
+		(mockResponse.emit as jest.Mock)('finish');
+
+		expect(logSpy).toHaveBeenCalledWith('❌ GET /test 500 - 100ms');
+
+		jest.useRealTimers();
+	});
+
+	it('should handle missing user-agent', () => {
+		mockRequest.get = jest.fn(() => '') as unknown as Request['get'];
+
+		middleware.use(mockRequest as Request, mockResponse as Response, mockNext);
+
+		expect(logSpy).toHaveBeenCalledWith('→ GET /test - 127.0.0.1 - ');
+	});
+
+	it('should calculate response time correctly', () => {
+		jest.useFakeTimers();
+
+		middleware.use(mockRequest as Request, mockResponse as Response, mockNext);
+
+		// Simula 150ms de processamento
+		jest.advanceTimersByTime(150);
+		mockResponse.statusCode = 201;
+		(mockResponse.emit as jest.Mock)('finish');
+
+		expect(logSpy).toHaveBeenCalledWith('✅ GET /test 201 - 150ms');
+
+		jest.useRealTimers();
+	});
+
+	it('should work with different HTTP methods', () => {
+		const methods = ['POST', 'PUT', 'DELETE', 'PATCH'];
+
+		methods.forEach((method) => {
+			jest.clearAllMocks();
+			mockRequest.method = method;
+
+			middleware.use(
+				mockRequest as Request,
+				mockResponse as Response,
+				mockNext,
+			);
+
+			expect(logSpy).toHaveBeenCalledWith(
+				expect.stringContaining(`→ ${method} /test`),
+			);
+		});
+	});
+
+	it('should register finish event listener on response', () => {
+		middleware.use(mockRequest as Request, mockResponse as Response, mockNext);
+
+		expect(mockResponse.on).toHaveBeenCalledWith(
+			'finish',
+			expect.any(Function),
+		);
+	});
+});


### PR DESCRIPTION
Criação de middleware para logar antes e depois da requisição. 

Fixes #23 